### PR TITLE
Fix typo in home page HTML

### DIFF
--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -21,7 +21,7 @@
         Open Source under MIT license.
       </p>
       <p>
-        CoderBox is implmented as a Progressive Web App (PWA) using Angular. We
+        CoderBox is implemented as a Progressive Web App (PWA) using Angular. We
         welcome any contribution, bug report on our GitHub repository.
       </p>
     </mat-card-content>


### PR DESCRIPTION
The word `implmented` should be spelled `implemented`.

This MR fixes that mistake.